### PR TITLE
이슈 수정

### DIFF
--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -129,7 +129,7 @@ const Home = () => {
 				<StackNavComponent stackRef={stackRef} updateStack={updateStack} feedbackFilter={feedbackFilter} />
 				<Container className={classes.cardGrid} maxWidth="md">
 					<SortComponent handleChangeSort={handleChangeSort} />
-					<Grid container spacing={4} style={{ backgroundColor: 'white', marginTop: '1vw', minHeight: '600px' }}>
+					<Grid container spacing={4} style={{ backgroundColor: 'white', marginTop: '1vw' }}>
 						{renderPosts()}
 					</Grid>
 					<div className={classes.loadingContainer}>{returnComponentThatisLoadingToClickButton()}</div>

--- a/src/utils/axiosHeader.ts
+++ b/src/utils/axiosHeader.ts
@@ -9,9 +9,9 @@ export interface HeaderConfig {
 
 export const headerConfig = (): HeaderConfig => {
 	const token = cookie.get('refresh_token');
-	const config = {
+	const config = token && {
 		headers: {
-			token: token ? token : '',
+			token: token,
 		},
 	};
 


### PR DESCRIPTION
## 요약
- 메인 페이지 `height`길이가 고정으로 되어있어 포스트(게시글)들이 세로로 길어지는 현상 수정
- token값이 빈문자열로 파싱되는 이슈 해결